### PR TITLE
[HGNN-1001] triggerback 옵션 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-inappbrowser",
-  "version": "5.0.7-hogangnono",
+  "version": "5.0.8-hogangnono",
   "description": "Cordova InAppBrowser Plugin",
   "types": "./types/index.d.ts",
   "cordova": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-inappbrowser",
-  "version": "5.0.8-hogangnono",
+  "version": "5.0.9-hogangnono",
   "description": "Cordova InAppBrowser Plugin",
   "types": "./types/index.d.ts",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,7 +20,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
            id="cordova-plugin-inappbrowser"
-      version="5.0.8-hogangnono">
+      version="5.0.9-hogangnono">
 
     <name>InAppBrowser</name>
     <description>Cordova InAppBrowser Plugin</description>

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,7 +20,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
            id="cordova-plugin-inappbrowser"
-      version="5.0.7-hogangnono">
+      version="5.0.8-hogangnono">
 
     <name>InAppBrowser</name>
     <description>Cordova InAppBrowser Plugin</description>

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -105,6 +105,7 @@ public class InAppBrowser extends CordovaPlugin {
     private static final String CLEAR_ALL_CACHE = "clearcache";
     private static final String CLEAR_SESSION_CACHE = "clearsessioncache";
     private static final String HARDWARE_BACK_BUTTON = "hardwareback";
+    private static final String TRIGGER_BACK_BUTTON = "triggerback";
     private static final String MEDIA_PLAYBACK_REQUIRES_USER_ACTION = "mediaPlaybackRequiresUserAction";
     private static final String INTENT_PROTOCOL_START = "intent:";
     private static final String INTENT_PROTOCOL_INTENT = "#Intent;";
@@ -113,6 +114,7 @@ public class InAppBrowser extends CordovaPlugin {
     private static final String HOGANGNONO_SCHEME = "hogangnono://";
     private static final String SHOULD_PAUSE = "shouldPauseOnSuspend";
     private static final Boolean DEFAULT_HARDWARE_BACK = true;
+    private static final Boolean DEFAULT_TRIGGER_BACK = false;
     private static final String USER_WIDE_VIEW_PORT = "useWideViewPort";
     private static final String TOOLBAR_COLOR = "toolbarcolor";
     private static final String CLOSE_BUTTON_CAPTION = "closebuttoncaption";
@@ -140,6 +142,7 @@ public class InAppBrowser extends CordovaPlugin {
     private boolean clearAllCache = false;
     private boolean clearSessionCache = false;
     private boolean hadwareBackButton = true;
+    private boolean triggerBackButton = false;
     private boolean mediaPlaybackRequiresUserGesture = false;
     private boolean shouldPauseInAppBrowser = false;
     private boolean useWideViewPort = true;
@@ -590,6 +593,21 @@ public class InAppBrowser extends CordovaPlugin {
     }
 
     /**
+     * Hogangnono - Has the user set the trigger back button to go back
+     * @return boolean
+     */
+    public boolean isTriggerBack() {
+        return triggerBackButton;
+    }
+
+    /**
+     * Hogangnono - Execute javaScript for triggering back button
+     */
+    public void triggerBackButton() {
+        this.inAppWebView.loadUrl("javascript:backbutton()");
+    }
+
+    /**
      * Checks to see if it is possible to go forward one page in history, then does so.
      */
     private void goForward() {
@@ -666,6 +684,12 @@ public class InAppBrowser extends CordovaPlugin {
                 hadwareBackButton = hardwareBack.equals("yes") ? true : false;
             } else {
                 hadwareBackButton = DEFAULT_HARDWARE_BACK;
+            }
+            String triggerBack = features.get(TRIGGER_BACK_BUTTON);
+            if (triggerBack != null) {
+                triggerBackButton = triggerBack.equals("yes") ? true : false;
+            } else {
+                triggerBackButton = DEFAULT_TRIGGER_BACK;
             }
             String mediaPlayback = features.get(MEDIA_PLAYBACK_REQUIRES_USER_ACTION);
             if (mediaPlayback != null) {

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -604,7 +604,7 @@ public class InAppBrowser extends CordovaPlugin {
      * Hogangnono - Execute javaScript for triggering back button
      */
     public void triggerBackButton() {
-        this.inAppWebView.loadUrl("javascript:backbutton()");
+        this.inAppWebView.loadUrl("javascript:window.backbutton && window.backbutton()");
     }
 
     /**

--- a/src/android/InAppBrowserDialog.java
+++ b/src/android/InAppBrowserDialog.java
@@ -50,7 +50,12 @@ public class InAppBrowserDialog extends Dialog {
             if (this.inAppBrowser.hardwareBack() && this.inAppBrowser.canGoBack()) {
                 this.inAppBrowser.goBack();
             }  else {
-                this.inAppBrowser.closeDialog();
+                // Hogangnono - triggerback 옵션이 설정되어 있으면, 웹뷰를 닫지 않고 웹으로 backbutton 함수를 실행시킨다
+                if (this.inAppBrowser.isTriggerBack()) {
+                    this.inAppBrowser.triggerBackButton();
+                } else {
+                    this.inAppBrowser.closeDialog();
+                }
             }
         }
     }


### PR DESCRIPTION
- Android에서 back 키를 trigger하기 위해서 `triggerback` 이라는 옵션을 추가
- `triggerback` 옵션이 설정되어 있을 경우 웹뷰의 `backbutton` 함수를 실행
  - 웹뷰에 `backbutton` 함수가 정의 되어 있어야함 

참고
- https://nicgoon.tistory.com/192
- https://blog.naver.com/PostView.nhn?blogId=newyorkinms&logNo=220574570294&parentCategoryNo=&categoryNo=10&viewDate=&isShowPopularPosts=true&from=search