### PR TITLE
[HGNN-7039] 광고 BM 배너 관련 안드로이드 앱 작업

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-inappbrowser",
-  "version": "5.0.15-hogangnono",
+  "version": "5.0.16-hogangnono",
   "description": "Cordova InAppBrowser Plugin",
   "types": "./types/index.d.ts",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,7 +20,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
            id="cordova-plugin-inappbrowser"
-      version="5.0.15-hogangnono">
+      version="5.0.16-hogangnono">
 
     <name>InAppBrowser</name>
     <description>Cordova InAppBrowser Plugin</description>

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -1422,8 +1422,8 @@ public class InAppBrowser extends CordovaPlugin {
                     Intent intent =Intent.parseUri(url, Intent.URI_INTENT_SCHEME);
                     Uri uri = Uri.parse(intent.getDataString());
                     cordova.getActivity().startActivity(new Intent(Intent.ACTION_VIEW, uri));
-                } catch (URISyntaxException e) {
-                    LOG.e(LOG_TAG, e.getLocalizedMessage());
+                } catch(Exception e) {
+                    LOG.e(LOG_TAG, "Error Start Intent " + url + ": " + e.toString());
                 }
                 return true;
             }

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -380,6 +380,11 @@ public class InAppBrowser extends CordovaPlugin {
         if (shouldPauseInAppBrowser) {
             inAppWebView.onResume();
         }
+
+        // onelink를 통해 이동 후, 앱에 재 진입 시, 기존 페이지로 전환
+        if(edittext.getText().toString().contains("onelink.me")) {
+            goBack();
+        }
     }
 
     /**

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -1424,11 +1424,20 @@ public class InAppBrowser extends CordovaPlugin {
             else if (url.startsWith(INTENT_PROTOCOL_START)) {
                 // intent:// 실행코드 변경
                 try {
-                    Intent intent =Intent.parseUri(url, Intent.URI_INTENT_SCHEME);
-                    Uri uri = Uri.parse(intent.getDataString());
-                    cordova.getActivity().startActivity(new Intent(Intent.ACTION_VIEW, uri));
+                    Intent intent = Intent.parseUri(url, Intent.URI_INTENT_SCHEME);
+                    try {
+                        Uri uri = Uri.parse(intent.getDataString());
+                        cordova.getActivity().startActivity(new Intent(Intent.ACTION_VIEW, uri));
+                    } catch(Exception e) {
+                        LOG.e(LOG_TAG, "Error startActivity Intent " + url + ": " + e.toString());
+                        String fallbackUrl = intent.getStringExtra("browser_fallback_url");
+                        if(fallbackUrl != null) {
+                            LOG.d(LOG_TAG, "FallbackUrl : " + fallbackUrl);
+                            cordova.getActivity().startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(fallbackUrl)));
+                        }
+                    }
                 } catch(Exception e) {
-                    LOG.e(LOG_TAG, "Error Start Intent " + url + ": " + e.toString());
+                    LOG.e(LOG_TAG, "Error parseUri " + url + ": " + e.toString());
                 }
                 return true;
             }


### PR DESCRIPTION
<!--
- PR 제목은 단순 브랜치명이 아닌 작업내용의 대표문구 또는 이슈 제목이 들어가야합니다.
- 필수항목(*) 기재하지 않았을 경우, approve/merge 불가합니다.
- 주석은 내용 숙지 후 제거해도 무방합니다.
-->

# 관련 이슈*
<!-- 지라 링크를 달아주세요. 없을 경우 이슈에 대한 설명을 기재해주세요. -->

https://zigbang.atlassian.net/browse/HGNN-7039

# 작업 내용*
- wv 제거 
- intent 처리 구조 개선
- wv 제거에따른 onelink intent 처리를 위한 추가 로직 작업 ( 기타 3) 에 정리된 내용 참고 )
 
# 체크리스트*
<!-- 확인해야할 사항을 정리하고 확인해주세요. -->

- [x] PR 모든 항목을 빠짐없이 작성했습니다. (제목, 담당자, 라벨, 마일스톤 등)
- [x] m/www/app 환경에서 각각 테스트하였습니다.

# 기타
**1) onelink 를 webview 에서 실행할 경우, useragent wv 값에 따라 다르게 처리됨** ([플린이 정리해주신 내용](https://www.notion.so/zigbang/20240110-68e6eb60b2e04a37a542729d1348f90f#7ef539bc1ff34d3f8b21ac7c6ea22fd6))
(wv) 있을 경우: custom scheme으로 처리 ( ex. banktoss:// )
(wv) 없을 경우 : intent로 처리 ( ex. intent:// )

**2) custom scheme으로 처리할 경우, 광고 onelink가 추가될 때 마다 추가적으로 앱 배포 필요하기 때문에 wv 제거하는 방향으로 진행** 

**3) wv 제거에따라 onelink 동작이 달라지는 부분 추가 처리**
- [원링크 실행 후, 앱으로 돌아오면 원래 보던 페이지로 재진입 되지 않음](https://github.com/hogangnono/cordova-plugin-inappbrowser/pull/7/commits/60907c2ac266731a8d7c2b5ac1f7a1734859eece)
- [인텐트 실행이 불가능할 경우, 스토어 이동이 안됨](https://github.com/hogangnono/cordova-plugin-inappbrowser/pull/7/commits/13ea7e6754ca9ebf7788d8f21d3a2e7106853ef4)



