### PR TITLE
[HGNN-12812] InAppBrowser statusbarstyle 옵션 지원

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-inappbrowser",
-  "version": "5.0.26-hogangnono",
+  "version": "5.0.27-hogangnono",
   "description": "Cordova InAppBrowser Plugin",
   "types": "./types/index.d.ts",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,7 +20,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
            id="cordova-plugin-inappbrowser"
-      version="5.0.26-hogangnono">
+      version="5.0.27-hogangnono">
 
     <name>InAppBrowser</name>
     <description>Cordova InAppBrowser Plugin</description>

--- a/src/ios/CDVInAppBrowserOptions.h
+++ b/src/ios/CDVInAppBrowserOptions.h
@@ -45,6 +45,7 @@
 @property (nonatomic, assign) BOOL disallowoverscroll;
 @property (nonatomic, copy) NSString* beforeload;
 @property (nonatomic, assign) BOOL fullscreen;
+@property (nonatomic, copy) NSString* statusbarstyle;
 
 + (CDVInAppBrowserOptions*)parseOptions:(NSString*)options;
 

--- a/src/ios/CDVInAppBrowserOptions.m
+++ b/src/ios/CDVInAppBrowserOptions.m
@@ -46,6 +46,7 @@
         self.toolbartranslucent = YES;
         self.beforeload = @"";
         self.fullscreen = YES;
+        self.statusbarstyle = nil;
     }
 
     return self;

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -1151,10 +1151,14 @@ BOOL isExiting = FALSE;
 
 - (UIStatusBarStyle)preferredStatusBarStyle
 {
-    NSString* statusBarStylePreference = [self settingForKey:@"InAppBrowserStatusBarStyle"];
-    if (statusBarStylePreference && [statusBarStylePreference isEqualToString:@"lightcontent"]) {
+    // Per-open-call option takes priority over config.xml
+    NSString* style = _browserOptions.statusbarstyle
+        ? [_browserOptions.statusbarstyle lowercaseString]
+        : [self settingForKey:@"InAppBrowserStatusBarStyle"];
+
+    if ([style isEqualToString:@"lightcontent"]) {
         return UIStatusBarStyleLightContent;
-    } else if (statusBarStylePreference && [statusBarStylePreference isEqualToString:@"darkcontent"]) {
+    } else if ([style isEqualToString:@"darkcontent"]) {
         if (@available(iOS 13.0, *)) {
             return UIStatusBarStyleDarkContent;
         } else {


### PR DESCRIPTION
## Summary
- `open()` 호출 시 `statusbarstyle` 옵션으로 per-call 스테이터스바 스타일 지정 지원
- 옵션 미지정 시 기존 config.xml `InAppBrowserStatusBarStyle` fallback 유지
- 숨고 웹뷰(흰 배경)에서 스테이터스바 텍스트가 안 보이는 문제를 전역 설정 변경 없이 해결

## Changes
- `CDVInAppBrowserOptions.h/m`: `statusbarstyle` 프로퍼티 추가
- `CDVWKInAppBrowser.m`: `preferredStatusBarStyle`에서 `_browserOptions.statusbarstyle` 우선 체크
- `package.json`, `plugin.xml`: `5.0.26` → `5.0.27-hogangnono`

## Usage
```javascript
// 숨고 웹뷰 — 흰 배경
cordova.InAppBrowser.open(url, '_blank', 'statusbarstyle=darkcontent');

// 기본 — config.xml 설정 사용
cordova.InAppBrowser.open(url, '_blank');
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)