### PR TITLE
[HGNN-13392] open() 옵션으로 contentInsetAdjustmentBehavior 지원

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-inappbrowser",
-  "version": "5.0.27-hogangnono",
+  "version": "5.0.28-hogangnono",
   "description": "Cordova InAppBrowser Plugin",
   "types": "./types/index.d.ts",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,7 +20,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
            id="cordova-plugin-inappbrowser"
-      version="5.0.27-hogangnono">
+      version="5.0.28-hogangnono">
 
     <name>InAppBrowser</name>
     <description>Cordova InAppBrowser Plugin</description>

--- a/src/ios/CDVInAppBrowserOptions.h
+++ b/src/ios/CDVInAppBrowserOptions.h
@@ -43,6 +43,7 @@
 @property (nonatomic, assign) BOOL allowinlinemediaplayback;
 @property (nonatomic, assign) BOOL hidden;
 @property (nonatomic, assign) BOOL disallowoverscroll;
+@property (nonatomic, copy) NSString* contentinsetadjustmentbehavior;
 @property (nonatomic, copy) NSString* beforeload;
 @property (nonatomic, assign) BOOL fullscreen;
 @property (nonatomic, copy) NSString* statusbarstyle;

--- a/src/ios/CDVInAppBrowserOptions.m
+++ b/src/ios/CDVInAppBrowserOptions.m
@@ -39,6 +39,7 @@
         self.allowinlinemediaplayback = NO;
         self.hidden = NO;
         self.disallowoverscroll = NO;
+        self.contentinsetadjustmentbehavior = @"never";
         self.hidenavigationbuttons = NO;
         self.closebuttoncolor = nil;
         self.lefttoright = false;

--- a/src/ios/CDVWKInAppBrowser.h
+++ b/src/ios/CDVWKInAppBrowser.h
@@ -46,6 +46,7 @@
 - (void)show:(CDVInvokedUrlCommand*)command;
 - (void)hide:(CDVInvokedUrlCommand*)command;
 - (void)loadAfterBeforeload:(CDVInvokedUrlCommand*)command;
+- (void)setContentInsetAdjustmentBehavior:(CDVInvokedUrlCommand*)command;
 
 @end
 
@@ -72,6 +73,7 @@
 
 - (void)close;
 - (void)navigateTo:(NSURL*)url;
+- (void)applyContentInsetAdjustmentBehavior:(NSString*)value API_AVAILABLE(ios(11.0));
 // - (void)showLocationBar:(BOOL)show;
 // - (void)showToolBar:(BOOL)show : (NSString *) toolbarPosition;
 - (void)setCloseButtonTitle:(NSString*)title : (NSString*) colorString : (int) buttonIndex;

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -833,7 +833,16 @@ BOOL isExiting = FALSE;
 
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000
    if (@available(iOS 11.0, *)) {
-       [self.webView.scrollView setContentInsetAdjustmentBehavior:UIScrollViewContentInsetAdjustmentNever];
+       UIScrollViewContentInsetAdjustmentBehavior behavior = UIScrollViewContentInsetAdjustmentNever;
+       NSString* behaviorOption = [_browserOptions.contentinsetadjustmentbehavior lowercaseString];
+       if ([behaviorOption isEqualToString:@"automatic"]) {
+           behavior = UIScrollViewContentInsetAdjustmentAutomatic;
+       } else if ([behaviorOption isEqualToString:@"scrollableaxes"]) {
+           behavior = UIScrollViewContentInsetAdjustmentScrollableAxes;
+       } else if ([behaviorOption isEqualToString:@"always"]) {
+           behavior = UIScrollViewContentInsetAdjustmentAlways;
+       }
+       [self.webView.scrollView setContentInsetAdjustmentBehavior:behavior];
    }
 #endif
 

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -395,6 +395,18 @@ static CDVWKInAppBrowser* instance = nil;
     [self.inAppBrowserViewController navigateTo:url];
 }
 
+- (void)setContentInsetAdjustmentBehavior:(CDVInvokedUrlCommand*)command
+{
+    if (self.inAppBrowserViewController == nil) {
+        NSLog(@"Tried to set contentInsetAdjustmentBehavior on IAB after it was closed.");
+        return;
+    }
+    NSString* value = [command argumentAtIndex:0];
+    if (@available(iOS 11.0, *)) {
+        [self.inAppBrowserViewController applyContentInsetAdjustmentBehavior:value];
+    }
+}
+
 // This is a helper method for the inject{Script|Style}{Code|File} API calls, which
 // provides a consistent method for injecting JavaScript code into the document.
 //
@@ -833,16 +845,7 @@ BOOL isExiting = FALSE;
 
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000
    if (@available(iOS 11.0, *)) {
-       UIScrollViewContentInsetAdjustmentBehavior behavior = UIScrollViewContentInsetAdjustmentNever;
-       NSString* behaviorOption = [_browserOptions.contentinsetadjustmentbehavior lowercaseString];
-       if ([behaviorOption isEqualToString:@"automatic"]) {
-           behavior = UIScrollViewContentInsetAdjustmentAutomatic;
-       } else if ([behaviorOption isEqualToString:@"scrollableaxes"]) {
-           behavior = UIScrollViewContentInsetAdjustmentScrollableAxes;
-       } else if ([behaviorOption isEqualToString:@"always"]) {
-           behavior = UIScrollViewContentInsetAdjustmentAlways;
-       }
-       [self.webView.scrollView setContentInsetAdjustmentBehavior:behavior];
+       [self applyContentInsetAdjustmentBehavior:_browserOptions.contentinsetadjustmentbehavior];
    }
 #endif
 
@@ -1232,6 +1235,22 @@ BOOL isExiting = FALSE;
     } else {
         NSURLRequest* request = [NSURLRequest requestWithURL:url];
         [self.webView loadRequest:request];
+    }
+}
+
+- (void)applyContentInsetAdjustmentBehavior:(NSString*)value
+{
+    if (@available(iOS 11.0, *)) {
+        UIScrollViewContentInsetAdjustmentBehavior behavior = UIScrollViewContentInsetAdjustmentNever;
+        NSString* lc = [value lowercaseString];
+        if ([lc isEqualToString:@"automatic"]) {
+            behavior = UIScrollViewContentInsetAdjustmentAutomatic;
+        } else if ([lc isEqualToString:@"scrollableaxes"]) {
+            behavior = UIScrollViewContentInsetAdjustmentScrollableAxes;
+        } else if ([lc isEqualToString:@"always"]) {
+            behavior = UIScrollViewContentInsetAdjustmentAlways;
+        }
+        [self.webView.scrollView setContentInsetAdjustmentBehavior:behavior];
     }
 }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -83,6 +83,11 @@ interface InAppBrowser {
      * @param callback  The function that executes after the CSS is injected.
      */
     insertCSS(css: { code: string } | { file: string }, callback: () => void): void;
+    /**
+     * iOS only. Updates the WKWebView scrollView's contentInsetAdjustmentBehavior at runtime.
+     * @param value  'automatic' | 'scrollableAxes' | 'never' | 'always'
+     */
+    setContentInsetAdjustmentBehavior(value: 'automatic' | 'scrollableAxes' | 'never' | 'always'): void;
 }
 
 type InAppBrowserEventListenerOrEventListenerObject = InAppBrowserEventListener | InAppBrowserEventListenerObject;

--- a/www/inappbrowser.js
+++ b/www/inappbrowser.js
@@ -89,6 +89,14 @@
             } else {
                 throw new Error('insertCSS requires exactly one of code or file to be specified');
             }
+        },
+
+        /**
+         * iOS 전용. WKWebView scrollView의 contentInsetAdjustmentBehavior를 런타임에 변경.
+         * @param {'automatic' | 'scrollableAxes' | 'never' | 'always'} value
+         */
+        setContentInsetAdjustmentBehavior: function (value) {
+            exec(null, null, 'InAppBrowser', 'setContentInsetAdjustmentBehavior', [value]);
         }
     };
 


### PR DESCRIPTION
## Summary

- iOS WKWebView `scrollView.contentInsetAdjustmentBehavior`를 `open()` 옵션으로 설정 가능하도록 추가
- 기본값 `'never'`로 기존 동작 호환성 유지
- `'automatic'`, `'scrollableAxes'`, `'always'` 값 지원

## Why

기존에는 `contentInsetAdjustmentBehavior`가 `Never`로 하드코딩되어, 호스트 페이지에서 CSS `env(safe-area-inset-*)`으로 safe area를 직접 처리해야 했습니다. 외부 PG 결제 페이지(Hecto 등)처럼 safe area 처리를 할 수 없는 3rd-party 페이지를 InAppBrowser로 열 때 상단이 잘리는 이슈(HGNN-13392)가 있어, per-open 단위로 동작을 제어할 수 있도록 옵션화했습니다.

## Usage

```js
cordova.InAppBrowser.open(url, '_blank', 'contentInsetAdjustmentBehavior=automatic')
```

## Test plan

- [x] 옵션 미지정 시 기존 동작(Never) 유지 확인
- [x] `contentInsetAdjustmentBehavior=automatic` 전달 시 safe area만큼 content가 자동 보정되는지 확인
- [x] 호갱노노 클라이언트 숨고페이 → PG 결제 페이지에서 상단 잘림 해소 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)