### PR TITLE
fix(ios): Debug 빌드에서 InAppBrowser WKWebView를 Safari Inspector에 노출

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-inappbrowser",
-  "version": "5.0.28-hogangnono",
+  "version": "5.0.29-hogangnono",
   "description": "Cordova InAppBrowser Plugin",
   "types": "./types/index.d.ts",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,7 +20,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
            id="cordova-plugin-inappbrowser"
-      version="5.0.28-hogangnono">
+      version="5.0.29-hogangnono">
 
     <name>InAppBrowser</name>
     <description>Cordova InAppBrowser Plugin</description>

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -821,6 +821,12 @@ BOOL isExiting = FALSE;
 
     self.webView = [[WKWebView alloc] initWithFrame:webViewBounds configuration:configuration];
 
+#if defined(DEBUG) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 160400
+    if (@available(iOS 16.4, *)) {
+        self.webView.inspectable = YES;
+    }
+#endif
+
     [self.view addSubview:self.webView];
     [self.view sendSubviewToBack:self.webView];
 


### PR DESCRIPTION
## Summary

- iOS 16.4+ 에서 InAppBrowser의 WKWebView에 `inspectable = YES`를 세팅하여 Safari 웹 인스펙터로 디버깅 가능하도록 수정
- Debug 빌드(`#if defined(DEBUG)`)에서만 활성화 — Release 빌드에는 영향 없음
- `package.json` / `plugin.xml` 버전 `5.0.28-hogangnono` → `5.0.29-hogangnono`

## Why

iOS 16.4부터 WKWebView가 기본적으로 `inspectable = NO`로 동작하게 바뀌면서, Debug 빌드에서도 InAppBrowser로 띄운 페이지가 Safari 웹 인스펙터에 잡히지 않아 디버깅이 불가능했습니다.

호스트 앱의 메인 WKWebView는 `cordova-ios`의 [`CDVWebViewEngine.m`](https://github.com/apache/cordova-ios/blob/master/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m)에서 이미 Debug 기본값 `YES`로 대응되어 있으나, 이 플러그인이 생성하는 별도 WKWebView에는 대응이 없어 InAppBrowser 내부 페이지 디버깅이 막혀 있었습니다.

## Test plan

- [x] Debug 빌드 + iOS 16.4+ 기기에서 InAppBrowser로 페이지 open → Mac Safari의 `개발자용` 메뉴에 해당 WebView가 뜨는 것 확인
- [x] Release 빌드에서는 매크로로 인해 미컴파일되어 기존 동작 유지

## Related
- Upstream 관련: 본 포크는 5.x 기반이고 apache upstream은 6.x에서 `InspectableWebview` preference로 대응되어 있어 버전 gap을 메우는 패치입니다.