### PR TITLE
[HGNN-12812] 결제 앱 스킴/패키지 목록을 호스트 앱으로 이관

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-inappbrowser",
-  "version": "5.0.29-hogangnono",
+  "version": "5.0.30-hogangnono",
   "description": "Cordova InAppBrowser Plugin",
   "types": "./types/index.d.ts",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,7 +20,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
            id="cordova-plugin-inappbrowser"
-      version="5.0.29-hogangnono">
+      version="5.0.30-hogangnono">
 
     <name>InAppBrowser</name>
     <description>Cordova InAppBrowser Plugin</description>
@@ -44,58 +44,6 @@
             <feature name="InAppBrowser">
                 <param name="android-package" value="org.apache.cordova.inappbrowser.InAppBrowser"/>
             </feature>
-        </config-file>
-
-        <config-file parent="/manifest" target="AndroidManifest.xml">
-            <queries>
-                <!-- PortOne 결제 앱 패키지 (전체 목록) -->
-                <package android:name="com.kftc.bankpay.android" />
-                <package android:name="com.nhnent.payapp" />
-                <package android:name="com.lottemembers.android" />
-                <package android:name="com.ssg.serviceapp.android.egiftcertificate" />
-                <package android:name="com.inicis.kpay" />
-                <package android:name="com.tmoney.tmpay" />
-                <package android:name="viva.republica.toss" />
-                <package android:name="com.samsung.android.spay" />
-                <package android:name="com.kakao.talk" />
-                <package android:name="com.nhn.android.search" />
-                <package android:name="com.mysmilepay.app" />
-                <package android:name="kvp.jjy.MispAndroid320" />
-                <package android:name="com.kbcard.cxh.appcard" />
-                <package android:name="com.kbstar.reboot" />
-                <package android:name="com.kbstar.kbbank" />
-                <package android:name="com.samsung.android.spaylite" />
-                <package android:name="com.lge.lgpay" />
-                <package android:name="com.hanaskcard.paycla" />
-                <package android:name="kr.co.hanamembers.hmscustomer" />
-                <package android:name="com.hanaskcard.rocomo.potal" />
-                <package android:name="kr.co.citibank.citimobile" />
-                <package android:name="com.lcacApp" />
-                <package android:name="kr.co.samsungcard.mpocket" />
-                <package android:name="com.shcard.smartpay" />
-                <package android:name="com.shinhancard.smartshinhan" />
-                <package android:name="com.shinhan.smartcaremgr" />
-                <package android:name="com.hyundaicard.appcard" />
-                <package android:name="nh.smart.nhallonepay" />
-                <package android:name="nh.smart.card" />
-                <package android:name="net.ib.android.smcard" />
-                <package android:name="com.wooricard.smartapp" />
-                <package android:name="com.wooribank.smart.npib" />
-                <package android:name="com.TouchEn.mVaccine.webs" />
-                <package android:name="com.ahnlab.v3mobileplus" />
-                <package android:name="kr.co.shiftworks.vguardweb" />
-                <package android:name="com.lumensoft.touchenappfree" />
-                <package android:name="kr.co.kfcc.mobilebank" />
-                <package android:name="com.nh.cashcardapp" />
-                <package android:name="com.knb.psb" />
-                <package android:name="com.lguplus.paynow" />
-                <package android:name="com.kbankwith.smartbank" />
-                <package android:name="com.eg.android.AlipayGphone" />
-                <package android:name="com.sktelecom.tauth" />
-                <package android:name="com.lguplus.smartotp" />
-                <package android:name="com.kt.ktauth" />
-                <package android:name="kr.danal.app.damoum" />
-            </queries>
         </config-file>
 
         <source-file src="src/android/InAppBrowser.java" target-dir="src/org/apache/cordova/inappbrowser" />
@@ -147,59 +95,6 @@
         <config-file target="*-Info.plist" parent="LSApplicationQueriesSchemes">
             <array>
                 <string>googlechrome</string>
-                <!-- PortOne 결제 앱 스킴 (전체 목록) -->
-                <string>kftc-bankpay</string>
-                <string>ispmobile</string>
-                <string>hdcardappcardansimclick</string>
-                <string>smhyundaiansimclick</string>
-                <string>hyundaicardappcardid</string>
-                <string>shinhan-sr-ansimclick</string>
-                <string>shinhan-sr-ansimclick-naverpay</string>
-                <string>shinhan-sr-ansimclick-payco</string>
-                <string>shinhan-sr-ansimclick-lpay</string>
-                <string>shinhan-sr-ansimclick-mola</string>
-                <string>smshinhanansimclick</string>
-                <string>smailapp</string>
-                <string>kb-acp</string>
-                <string>kb-auth</string>
-                <string>kb-screen</string>
-                <string>kbbank</string>
-                <string>liivbank</string>
-                <string>newliiv</string>
-                <string>mpocket.online.ansimclick</string>
-                <string>ansimclickscard</string>
-                <string>ansimclickipcollect</string>
-                <string>vguardstart</string>
-                <string>samsungpay</string>
-                <string>scardcertiapp</string>
-                <string>monimopay</string>
-                <string>monimopayauth</string>
-                <string>lottesmartpay</string>
-                <string>lotteappcard</string>
-                <string>lmslpay</string>
-                <string>lpayapp</string>
-                <string>cloudpay</string>
-                <string>hanawalletmembers</string>
-                <string>nhappcardansimclick</string>
-                <string>nonghyupcardansimclick</string>
-                <string>nhallonepayansimclick</string>
-                <string>citispay</string>
-                <string>citicardappkr</string>
-                <string>citimobileapp</string>
-                <string>kakaotalk</string>
-                <string>payco</string>
-                <string>com.wooricard.wcard</string>
-                <string>newsmartpib</string>
-                <string>supertoss</string>
-                <string>naversearchthirdlogin</string>
-                <string>kakaobank</string>
-                <string>v3mobileplusweb</string>
-                <string>line</string>
-                <string>alipays</string>
-                <string>weixin</string>
-                <string>tauthlink</string>
-                <string>ktauthexternalcall</string>
-                <string>upluscorporation</string>
             </array>
         </config-file>
         <header-file src="src/ios/CDVInAppBrowserOptions.h" />


### PR DESCRIPTION
## Summary

PortOne 결제 앱 패키지(Android `<queries>`) / 스킴(iOS `LSApplicationQueriesSchemes`) 목록을 플러그인에서 제거하고, 호스트 앱 (`hogangnono-phonegap`) `config.xml` 에서 선언하도록 책임을 이관.

플러그인은 **메커니즘**(non-web 커스텀 스킴이 들어오면 외부 앱으로 위임) 만 제공하고, **정책**(어떤 스킴/패키지를 등록할지) 은 호스트 앱이 결정하도록 레이어링 정리.

- 버전: `5.0.29-hogangnono` → `5.0.30-hogangnono`

## 이관 사유

1. **관심사 분리** — 결제 앱 목록은 호갱노노라는 호스트 앱의 비즈니스 도메인 지식이지 InAppBrowser의 책임이 아님
2. **변경 비용** — 결제 앱은 자주 바뀌는데, fork 플러그인에 박혀 있으면 추가/제거할 때마다 plugin PR → 버전 bump → 본 앱 plugin 업데이트 흐름이 매번 필요. 호스트 앱 config.xml 에 두면 PR 1개로 끝
3. **Fork divergence 축소** — upstream `cordova-plugin-inappbrowser` 와의 fork 표면적을 메커니즘 변경(커스텀 스킴 핸들러, statusbarstyle, contentInsetAdjustmentBehavior, Debug inspectable)으로만 한정
4. **Cordova 컨벤션** — `LSApplicationQueriesSchemes` / Android `<queries>` 는 본래 앱 레벨 `config.xml` 에서 선언하는 것이 표준

## Related

- 원래 추가했던 PR: #13
- 호스트 앱 PR: hogangnono/hogangnono-phonegap#264
- 코드 리뷰 코멘트: hogangnono/hogangnono-phonegap#264 (issuecomment-4312402153) / hogangnono/cordova-plugin-inappbrowser#13 (discussion_r3136998540)
- Task: [HGNN-12812](https://hogangnono.atlassian.net/browse/HGNN-12812)

## ⚠️ 호스트 앱 동반 변경 필요

이 PR 머지 후 호스트 앱(`hogangnono-phonegap`) `config.xml` 에 동일 결제 스킴/패키지 목록을 추가해야 결제 앱 호출이 정상 동작함. 호스트 앱 작업은 PR #264 에서 함께 진행.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[HGNN-12812]: https://zigbang.atlassian.net/browse/HGNN-12812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ