### PR TITLE
feat(HGNN-13659): contentInsetAdjustmentBehavior가 never가 아닌 경우 webView frame을 safe area 아래로 보정

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-inappbrowser",
-  "version": "5.0.30-hogangnono",
+  "version": "5.0.31-hogangnono",
   "description": "Cordova InAppBrowser Plugin",
   "types": "./types/index.d.ts",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,7 +20,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
            id="cordova-plugin-inappbrowser"
-      version="5.0.30-hogangnono">
+      version="5.0.31-hogangnono">
 
     <name>InAppBrowser</name>
     <description>Cordova InAppBrowser Plugin</description>

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -834,6 +834,9 @@ BOOL isExiting = FALSE;
     self.webView.navigationDelegate = self;
     self.webView.UIDelegate = self.webViewUIDelegate;
     self.webView.backgroundColor = [UIColor whiteColor];
+    if (![_browserOptions.contentinsetadjustmentbehavior isEqualToString:@"never"]) {
+        self.view.backgroundColor = [UIColor whiteColor];
+    }
     if ([self settingForKey:@"OverrideUserAgent"] != nil) {
         self.webView.customUserAgent = [self settingForKey:@"OverrideUserAgent"];
     }
@@ -1156,6 +1159,27 @@ BOOL isExiting = FALSE;
 - (void)viewDidLoad
 {
     [super viewDidLoad];
+}
+
+- (void)viewDidLayoutSubviews
+{
+    [super viewDidLayoutSubviews];
+
+    if ([_browserOptions.contentinsetadjustmentbehavior isEqualToString:@"never"] || self.webView == nil) {
+        return;
+    }
+
+    if (@available(iOS 11.0, *)) {
+        CGFloat topInset = self.view.safeAreaInsets.top;
+        CGRect bounds = self.view.bounds;
+        CGRect target = CGRectMake(bounds.origin.x,
+                                   bounds.origin.y + topInset,
+                                   bounds.size.width,
+                                   bounds.size.height - topInset);
+        if (!CGRectEqualToRect(self.webView.frame, target)) {
+            self.webView.frame = target;
+        }
+    }
 }
 
 - (void)viewDidDisappear:(BOOL)animated


### PR DESCRIPTION
# 관련 이슈*

[HGNN-13659](https://zigbang.atlassian.net/browse/HGNN-13659)

# 작업 내용*

iOS WKWebView로 자체 safe area 처리(`viewport-fit=cover`)를 안 하는 외부 페이지(토스페이 결제 등)를 IAB로 띄울 때, 스크롤/오버스크롤 과정에서 콘텐츠가 status bar 영역에 노출되는 문제 해결.

기존 `open()` 옵션의 `contentInsetAdjustmentBehavior`는 `WKWebView.scrollView`의 프로퍼티만 설정하고, webview frame 자체는 풀스크린(`self.view.bounds`)이라 status bar 영역까지 콘텐츠가 그려질 수 있었다.

이번 변경 (`src/ios/CDVWKInAppBrowser.m`):
- `contentinsetadjustmentbehavior`가 `'never'`가 아닐 때, `viewDidLayoutSubviews`에서 `self.view.safeAreaInsets.top`만큼 `webView.frame`을 아래로 보정 → scroll bounce/contentOffset과 무관하게 status bar 영역 침범 차단
- 옵션이 `'never'`가 아닐 때 `self.view.backgroundColor`를 white로 설정 → webview가 내려간 영역이 검은 빈 영역으로 비치지 않게
- 기본값이 `'never'`라 명시 지정 안 한 기존 호출자는 영향 없음 (backwards compatible)

릴리즈: `5.0.31-hogangnono` (npm.housefeed.com publish 완료)

# 체크리스트*

- [x] PR 모든 항목을 빠짐없이 작성했습니다. (제목, 담당자, 라벨, 마일스톤 등)
- [x] app 환경에서 테스트하였습니다 (iPhone 15 시뮬레이터, Dynamic Island)
  - 토스페이 결제 진입 후 오버스크롤 → status bar 영역에 콘텐츠 노출 없음
  - 회전 → 복귀 후 webView frame이 새 safe area에 맞춰 재정렬
  - `contentInsetAdjustmentBehavior` 미지정(기본 `'never'`) 호출 경로는 기존과 동일하게 풀스크린 동작
  - iOS only 변경 — m/www는 해당 없음

# 기타

- 호출 측 후속: hogangnono-client `useHomecareInAppBrowser`의 토스 전용 `insertCSS` hack 제거 PR이 이어짐
- phonegap 측 `package.json`에서 `cordova-plugin-inappbrowser` 버전을 `^5.0.31-hogangnono`로 bump 후 iOS 빌드 필요

[HGNN-13659]: https://zigbang.atlassian.net/browse/HGNN-13659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ