### PR TITLE
refactor(HGNN-13659): self.view backgroundColor 강제 설정 제거

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-inappbrowser",
-  "version": "5.0.31-hogangnono",
+  "version": "5.0.32-hogangnono",
   "description": "Cordova InAppBrowser Plugin",
   "types": "./types/index.d.ts",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,7 +20,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
            id="cordova-plugin-inappbrowser"
-      version="5.0.31-hogangnono">
+      version="5.0.32-hogangnono">
 
     <name>InAppBrowser</name>
     <description>Cordova InAppBrowser Plugin</description>

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -834,9 +834,6 @@ BOOL isExiting = FALSE;
     self.webView.navigationDelegate = self;
     self.webView.UIDelegate = self.webViewUIDelegate;
     self.webView.backgroundColor = [UIColor whiteColor];
-    if (![_browserOptions.contentinsetadjustmentbehavior isEqualToString:@"never"]) {
-        self.view.backgroundColor = [UIColor whiteColor];
-    }
     if ([self settingForKey:@"OverrideUserAgent"] != nil) {
         self.webView.customUserAgent = [self settingForKey:@"OverrideUserAgent"];
     }


### PR DESCRIPTION
# 관련 이슈*

[HGNN-13659](https://zigbang.atlassian.net/browse/HGNN-13659)

# 작업 내용*

#18 에서 추가됐던 `self.view.backgroundColor = whiteColor` 불필요 라인을 제거.

# 체크리스트*

- [x] PR 모든 항목을 빠짐없이 작성했습니다. (제목, 담당자, 라벨, 마일스톤 등)

# 기타

- phonegap PR #277의 IAB 버전 bump를 `^5.0.31-hogangnono` → `^5.0.32-hogangnono`로 함께 갱신해야 함

[HGNN-13659]: https://zigbang.atlassian.net/browse/HGNN-13659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ